### PR TITLE
Adds travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,21 +29,6 @@ matrix:
             - libboost-program-options-dev
             - libboost-system-dev
           sources: *sources
-    - os: linux
-      env: CXX="clang++-6.0" CC="clang-6.0"
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - clang-6.0
-            - g++-8
-            - cmake
-            - libboost-program-options-dev
-            - libboost-system-dev
-          sources:
-            - llvm-toolchain-xenial-6.0
-            - ubuntu-toolchain-r-test
-
 script:
   - cmake --version
   - cmake .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: generic
+
+dist: xenial
+
+matrix:
+  include:
+    - os: linux
+      env: CXX="g++-7" CC="gcc-7"
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+            - cmake
+            - cmake-data
+            - libssl-dev
+          sources: &sources
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: CXX="g++-8" CC="gcc-8"
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-8
+            - g++-8
+            - cmake
+            - cmake-data
+            - libssl-dev
+          sources: *sources
+    - os: linux
+      env: CXX="clang++-5.0" CC="clang-5.0"
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-8
+            - cmake
+            - cmake-data
+            - protobuf-compiler
+            - libssl-dev
+          sources:
+            - llvm-toolchain-xenial-5.0
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: CXX="clang++-6.0" CC="clang-6.0"
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - clang-6.0
+            - g++-8
+            - cmake
+            - cmake-data
+            - libssl-dev
+          sources:
+            - llvm-toolchain-xenial-6.0
+            - ubuntu-toolchain-r-test
+
+script:
+  - cmake --version
+  - cmake .
+  - make -j 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
             - gcc-7
             - g++-7
             - cmake
-            - cmake-data
-            - libssl-dev
           sources: &sources
             - ubuntu-toolchain-r-test
     - os: linux
@@ -26,8 +24,6 @@ matrix:
             - gcc-8
             - g++-8
             - cmake
-            - cmake-data
-            - libssl-dev
           sources: *sources
     - os: linux
       env: CXX="clang++-5.0" CC="clang-5.0"
@@ -38,9 +34,6 @@ matrix:
             - clang-5.0
             - g++-8
             - cmake
-            - cmake-data
-            - protobuf-compiler
-            - libssl-dev
           sources:
             - llvm-toolchain-xenial-5.0
             - ubuntu-toolchain-r-test
@@ -53,8 +46,6 @@ matrix:
             - clang-6.0
             - g++-8
             - cmake
-            - cmake-data
-            - libssl-dev
           sources:
             - llvm-toolchain-xenial-6.0
             - ubuntu-toolchain-r-test
@@ -63,3 +54,4 @@ script:
   - cmake --version
   - cmake .
   - make -j 2
+  - ctest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,20 @@ matrix:
             - libboost-program-options-dev
             - libboost-system-dev
           sources: *sources
+    - os: linux
+      env: CXX="clang++-6.0" CC="clang-6.0"
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - clang-6.0
+            - g++-8
+            - cmake
+            - libboost-program-options-dev
+            - libboost-system-dev
+          sources:
+            - llvm-toolchain-xenial-6.0
+            - ubuntu-toolchain-r-test
 script:
   - cmake --version
   - cmake .

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,21 +43,6 @@ matrix:
           sources:
             - llvm-toolchain-xenial-6.0
             - ubuntu-toolchain-r-test
-    - os: linux
-      env: CXX="clang++-libc++" CC="clang-6.0"
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - clang-6.0
-            - libc++-dev
-            - g++-8
-            - cmake
-            - libboost-program-options-dev
-            - libboost-system-dev
-          sources:
-            - llvm-toolchain-xenial-6.0
-            - ubuntu-toolchain-r-test
 script:
   - cmake --version
   - cmake .

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
             - gcc-7
             - g++-7
             - cmake
+            - libboost-program-options-dev
+            - libboost-system-dev
           sources: &sources
             - ubuntu-toolchain-r-test
     - os: linux
@@ -24,19 +26,9 @@ matrix:
             - gcc-8
             - g++-8
             - cmake
+            - libboost-program-options-dev
+            - libboost-system-dev
           sources: *sources
-    - os: linux
-      env: CXX="clang++-5.0" CC="clang-5.0"
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - clang-5.0
-            - g++-8
-            - cmake
-          sources:
-            - llvm-toolchain-xenial-5.0
-            - ubuntu-toolchain-r-test
     - os: linux
       env: CXX="clang++-6.0" CC="clang-6.0"
       compiler: clang
@@ -46,6 +38,8 @@ matrix:
             - clang-6.0
             - g++-8
             - cmake
+            - libboost-program-options-dev
+            - libboost-system-dev
           sources:
             - llvm-toolchain-xenial-6.0
             - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,21 @@ matrix:
           sources:
             - llvm-toolchain-xenial-6.0
             - ubuntu-toolchain-r-test
+    - os: linux
+      env: CXX="clang++-libc++" CC="clang-6.0"
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - clang-6.0
+            - libc++-dev
+            - g++-8
+            - cmake
+            - libboost-program-options-dev
+            - libboost-system-dev
+          sources:
+            - llvm-toolchain-xenial-6.0
+            - ubuntu-toolchain-r-test
 script:
   - cmake --version
   - cmake .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,37 +6,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 
 include(cmake/DefaultBuildType.cmake)
 
-include(CheckCXXSymbolExists)
+find_package(StdFilesystem REQUIRED)
 
-add_library(std::filesystem INTERFACE IMPORTED)
-set(CMAKE_REQUIRED_FLAGS "-std=c++17")
-CHECK_CXX_SYMBOL_EXISTS(std::filesystem::status_known filesystem HAS_STD_FILESYSTEM)
-set(CMAKE_REQUIRED_LIBRARIES "stdc++fs")
-CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::status_known experimental/filesystem HAS_EXPERIMENTAL_STD_FILESYSTEM)
-unset(CMAKE_REQUIRED_LIBRARIES)
-unset(CMAKE_REQUIRED_FLAGS)
-if(NOT HAS_STD_FILESYSTEM)
-    if(NOT HAS_EXPERIMENTAL_STD_FILESYSTEM)
-        message(SEND_ERROR "Cannot find std::filesystem, but it is required. Please use a fully C++17 compliant compiler.")
-    else()
-        set_target_properties(std::filesystem PROPERTIES INTERFACE_COMPILE_DEFINITIONS HAS_EXPERIMENTAL_STD_FILESYSTEM)
-        # libstdc++ needs an extra lib for filesystem
-        target_link_libraries(std::filesystem INTERFACE
-            $<$<CXX_COMPILER_ID:GNU>:stdc++fs>
-            $<$<CXX_COMPILER_ID:AppleClang>:c++fs>
-            $<$<CXX_COMPILER_ID:Clang>:c++fs>
-        )
-    endif()
-else()
-    set_target_properties(std::filesystem PROPERTIES INTERFACE_COMPILE_DEFINITIONS HAS_STD_FILESYSTEM)
-    # libstdc++ needs an extra lib for filesystem
-    target_link_libraries(std::filesystem INTERFACE
-        $<$<CXX_COMPILER_ID:GNU>:stdc++fs>
-        $<$<CXX_COMPILER_ID:AppleClang>:c++fs>
-        $<$<CXX_COMPILER_ID:Clang>:c++fs>
-    )
-
-endif()
 
 add_subdirectory(lib/catch)
 add_subdirectory(lib/json)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/metricq/hta.svg?branch=master)](https://travis-ci.com/metricq/hta)
+
 Hierarchical Timeline Aggregation
 =================================
 

--- a/cmake/FindStdFilesystem.cmake
+++ b/cmake/FindStdFilesystem.cmake
@@ -80,7 +80,6 @@ if(NOT _HAS_INTEGRATED_STD_FILESYSTEM)
     check_cxx_source_compiles("${_CHECK_FILESYSTEM_CODE}" _HAS_BUNDLED_FILESYSTEM_LIBRARY)
     unset(CMAKE_REQUIRED_LIBRARIES)
 endif()
-
 unset(CMAKE_REQUIRED_FLAGS)
 
 # if we only have it in experimental, we still have it
@@ -94,18 +93,18 @@ if(NOT _HAS_INTEGRATED_STD_FILESYSTEM AND NOT _HAS_BUNDLED_FILESYSTEM_LIBRARY)
     elseif(HAS_LIBCXX)
         find_library(StdFilesystem_LIBRARY NAMES ${StdFSLibName} HINTS ENV LD_LIBRARY_PATH ENV LIBRARY_PATH ENV DYLD_LIBRARY_PATH)
     else()
-        message(WARNING "Couldn't detect your C++ standard library, but also couldn't link without an additional library. You'll probably receive linker errors.")
+        message(WARNING "Couldn't detect your C++ standard library, but also couldn't link without an additional library. This is bad.")
     endif()
 
     find_package_handle_standard_args(StdFilesystem
-        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and stdandard library."
+        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and standard library."
         StdFilesystem_LIBRARY
         HAS_STD_FILESYSTEM
     )
 else()
     set(OUTPUT_MESSAGE "Compiler integrated")
     find_package_handle_standard_args(StdFilesystem
-        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and stdandard library."
+        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and st andard library."
         OUTPUT_MESSAGE
         HAS_STD_FILESYSTEM
     )
@@ -120,6 +119,7 @@ if(StdFilesystem_FOUND)
         target_link_libraries(std::filesystem INTERFACE ${StdFilesystem_LIBRARY})
     elseif(_HAS_BUNDLED_FILESYSTEM_LIBRARY)
         target_link_libraries(std::filesystem INTERFACE ${StdFSLibName})
+        set(StdFilesystem_LIBRARY ${StdFSLibName})
     endif()
 
     if(HAS_EXPERIMENTAL_STD_FILESYSTEM)

--- a/cmake/FindStdFilesystem.cmake
+++ b/cmake/FindStdFilesystem.cmake
@@ -102,7 +102,11 @@ if(NOT _HAS_INTEGRATED_STD_FILESYSTEM AND NOT _HAS_BUNDLED_FILESYSTEM_LIBRARY)
         HAS_STD_FILESYSTEM
     )
 else()
-    set(OUTPUT_MESSAGE "Compiler integrated")
+    if(_HAS_INTEGRATED_STD_FILESYSTEM)
+        set(OUTPUT_MESSAGE "Compiler integrated")
+    else()
+        set(OUTPUT_MESSAGE "Using -l${StdFSLibName}")
+    endif()
     find_package_handle_standard_args(StdFilesystem
         "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and st andard library."
         OUTPUT_MESSAGE

--- a/cmake/FindStdFilesystem.cmake
+++ b/cmake/FindStdFilesystem.cmake
@@ -118,7 +118,7 @@ if(StdFilesystem_FOUND)
 
     if(NOT _HAS_INTEGRATED_STD_FILESYSTEM AND NOT _HAS_BUNDLED_FILESYSTEM_LIBRARY)
         target_link_libraries(std::filesystem INTERFACE ${StdFilesystem_LIBRARY})
-    elseif(NOT _HAS_BUNDLED_FILESYSTEM_LIBRARY)
+    elseif(_HAS_BUNDLED_FILESYSTEM_LIBRARY)
         target_link_libraries(std::filesystem INTERFACE ${StdFSLibName})
     endif()
 

--- a/cmake/FindStdFilesystem.cmake
+++ b/cmake/FindStdFilesystem.cmake
@@ -1,0 +1,100 @@
+# Copyright (c) 2019, ZIH, Technische Universitaet Dresden, Federal Republic of Germany
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimer in the documentation
+#       and/or other materials provided with the distribution.
+#     * Neither the name of metricq nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(FindPackageHandleStandardArgs)
+include(CheckCXXSymbolExists)
+
+if (StdFilesystem_LIBRARY)
+    set(StdFilesystem_FIND_QUIETLY TRUE)
+endif()
+
+# detect the stdlib we are using
+CHECK_CXX_SYMBOL_EXISTS(_LIBCPP_VERSION ciso646 HAS_LIBCXX)
+CHECK_CXX_SYMBOL_EXISTS(__GLIBCXX__ ciso646 HAS_LIBSTDCXX)
+
+# detect if the headers are present
+set(CMAKE_REQUIRED_FLAGS "-std=c++17")
+CHECK_CXX_SYMBOL_EXISTS(std::filesystem::status_known filesystem HAS_STD_FILESYSTEM)
+CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::status_known experimental/filesystem HAS_EXPERIMENTAL_STD_FILESYSTEM)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
+# check if we need to link an additional library
+if(HAS_STD_FILESYSTEM)
+    CHECK_CXX_SYMBOL_EXISTS(std::filesystem::exists filesystem NEEDS_STD_FILESYSTEM_LIBRARY)
+elseif(HAS_EXPERIMENTAL_STD_FILESYSTEM)
+    CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::exists filesystem _DONT_NEED_STD_FILESYSTEM_LIBRARY)
+endif()
+unset(CMAKE_REQUIRED_FLAGS)
+
+# if we only have it in experimental, we still have it
+if(HAS_EXPERIMENTAL_STD_FILESYSTEM)
+    set(HAS_STD_FILESYSTEM TRUE)
+endif()
+
+if(NOT _DONT_NEED_STD_FILESYSTEM_LIBRARY)
+    if(HAS_LIBSTDCXX)
+        set(StdFSLibName "stdc++fs")
+        find_library(StdFilesystem_LIBRARY NAMES ${StdFSLibName} HINTS ENV LD_LIBRARY_PATH ENV LIBRARY_PATH ENV DYLD_LIBRARY_PATH)
+    elseif(HAS_LIBCXX)
+        set(StdFSLibName "c++fs")
+        find_library(StdFilesystem_LIBRARY NAMES ${StdFSLibName} HINTS ENV LD_LIBRARY_PATH ENV LIBRARY_PATH ENV DYLD_LIBRARY_PATH)
+    else()
+        message(WARNING "Couldn't detect your C++ standard library, but also couldn't link without an additional library. You'll probably receive linker errors.")
+    endif()
+
+    find_package_handle_standard_args(StdFilesystem
+        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and stdandard library."
+        StdFilesystem_LIBRARY
+        HAS_STD_FILESYSTEM
+    )
+else()
+    set(OUTPUT_MESSAGE "Compiler integrated")
+    find_package_handle_standard_args(StdFilesystem
+        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and stdandard library."
+        OUTPUT_MESSAGE
+        HAS_STD_FILESYSTEM
+    )
+endif()
+
+# if we have found it, let's define the std::filesystem target
+if(StdFilesystem_FOUND)
+    add_library(std::filesystem INTERFACE IMPORTED)
+    target_compile_features(std::filesystem INTERFACE cxx_std_17)
+
+    if(NOT _DONT_NEED_STD_FILESYSTEM_LIBRARY)
+        target_link_libraries(std::filesystem INTERFACE ${StdFilesystem_LIBRARY})
+    endif()
+
+    if(HAS_EXPERIMENTAL_STD_FILESYSTEM)
+        set_target_properties(std::filesystem PROPERTIES INTERFACE_COMPILE_DEFINITIONS HAS_EXPERIMENTAL_STD_FILESYSTEM)
+    else()
+        set_target_properties(std::filesystem PROPERTIES INTERFACE_COMPILE_DEFINITIONS HAS_STD_FILESYSTEM)
+    endif()
+
+    mark_as_advanced(StdFilesystem_LIBRARY)
+endif()


### PR DESCRIPTION
Clang doesn't work, because std::filesystem is a nightmare. Not only do you have to link an extra library, it depends on the standard lib the compiler is using, which one you'll need. A Clang on Linux defaults to libstdc++, but there are still clang version using libc++. An AppleClang on Mac OS is detected as Clang by CMake. This whole situation is such a piece of 💩. 

Pragmatic solutions: Don't give a damn. 🤷‍♂️